### PR TITLE
performance improvements when rendering tables

### DIFF
--- a/render_test.go
+++ b/render_test.go
@@ -5,9 +5,9 @@
 package tablecli
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,7 +74,7 @@ func TestColumnsSize(t *testing.T) {
 func TestSeparator(t *testing.T) {
 	table := NewTable()
 	expected := "+-------+---+\n"
-	buf := bytes.NewBuffer(nil)
+	buf := &strings.Builder{}
 	table.separator(buf, []int{5, 1})
 	assert.Equal(t, expected, buf.String())
 }
@@ -450,6 +450,42 @@ jk`}, tb.rows[0])
 }
 
 func BenchmarkString(b *testing.B) {
+	b.StopTimer()
+	table := NewTable()
+	table.Headers = Row{"row 1", "row 2", "row 3", "row 4"}
+	for i := 0; i < 100; i++ {
+		table.AddRow(Row{"my big string", "other string", "small", `largest string in the whole table
+continuing string
+another line
+yet another big line`})
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_ = table.String()
+	}
+}
+
+func BenchmarkStringWithColor(b *testing.B) {
+	b.StopTimer()
+	table := NewTable()
+	table.Headers = Row{"row 1", "row 2", "row 3", "row 4"}
+	for i := 0; i < 100; i++ {
+		table.AddRow(Row{"my " + withColor("big") + " string", withColor("other string"), "small", `largest string in the whole table
+continuing string
+another line
+yet another big line`})
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_ = table.String()
+	}
+}
+
+func BenchmarkStringWithResize(b *testing.B) {
+	TableConfig.MaxTTYWidth = 52
+	defer func() {
+		TableConfig.MaxTTYWidth = 0
+	}()
 	b.StopTimer()
 	table := NewTable()
 	table.Headers = Row{"row 1", "row 2", "row 3", "row 4"}


### PR DESCRIPTION
```
$ benchstat old.txt new.txt
name                old time/op    new time/op    delta
String-4              1.34ms ± 5%    0.46ms ± 1%  -65.58%  (p=0.001 n=6+7)
StringWithColor-4     1.62ms ± 2%    0.87ms ± 3%  -46.55%  (p=0.001 n=7+7)
StringWithResize-4    4.31ms ± 1%    1.41ms ± 1%  -67.19%  (p=0.001 n=6+7)

name                old alloc/op   new alloc/op   delta
String-4               463kB ± 0%     253kB ± 0%  -45.31%  (p=0.001 n=7+7)
StringWithColor-4      482kB ± 0%     384kB ± 0%  -20.25%  (p=0.000 n=6+7)
StringWithResize-4    1.19MB ± 0%    0.74MB ± 0%  -37.88%  (p=0.008 n=6+7)

name                old allocs/op  new allocs/op  delta
String-4               15.3k ± 0%      5.0k ± 0%  -66.97%  (p=0.001 n=7+7)
StringWithColor-4      15.7k ± 0%      6.2k ± 0%  -60.14%  (p=0.001 n=7+7)
StringWithResize-4     51.6k ± 0%     15.6k ± 0%  -69.86%  (p=0.001 n=7+7)
```